### PR TITLE
Fix unhandled exception

### DIFF
--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -176,7 +176,7 @@ function buildServicesFor (name, packet, txt, referer) {
             service.subtypes = types.subtypes
           } else if (rr.type === 'TXT') {
             service.rawTxt = rr.data
-            service.txt = txt.decode(rr.data)
+            service.txt = txt.decode(Buffer.from(rr.data))
           }
         })
 

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -175,8 +175,11 @@ function buildServicesFor (name, packet, txt, referer) {
             service.protocol = types.protocol
             service.subtypes = types.subtypes
           } else if (rr.type === 'TXT') {
+            // rr.data is an Array of Buffer instead of Buffer
             service.rawTxt = rr.data
-            service.txt = txt.decode(Buffer.from(rr.data))
+            service.txt = rr.data.reduce((acc, elt) => {
+              return Object.assign(acc, txt.decode(elt))
+            }, {})
           }
         })
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/watson/bonjour.git"
+    "url": "https://github.com/KhaosT/bonjour.git"
   },
   "keywords": [
     "bonjour",
@@ -42,7 +42,7 @@
   "bugs": {
     "url": "https://github.com/watson/bonjour/issues"
   },
-  "homepage": "https://github.com/watson/bonjour",
+  "homepage": "https://github.com/KhaosT/bonjour",
   "coordinates": [
     55.68250900965318,
     12.586377442991648


### PR DESCRIPTION
`txt.decode()` throws an error when its argument is not a `Buffer`.  `rr.data` is an `Array` of `Buffer` instead of a `Buffer`.  Not sure what exactly caused the change, but it seems to be introduced in 3.5.2 with the bump of `multicast-dns`.
```
TypeError: buffer is not a buffer
at bufferIndexOf (/Users/ebaauw/GitHub/homebridge-lib/node_modules/buffer-indexof/index.js:3:11)
at Object.that.decode (/Users/ebaauw/GitHub/homebridge-lib/node_modules/dns-txt/index.js:55:15)
at /Users/ebaauw/GitHub/homebridge-lib/node_modules/bonjour-hap/lib/Browser.js:179:31
at Array.forEach (<anonymous>)
at /Users/ebaauw/GitHub/homebridge-lib/node_modules/bonjour-hap/lib/Browser.js:164:10
at Array.map (<anonymous>)
at buildServicesFor (/Users/ebaauw/GitHub/homebridge-lib/node_modules/bonjour-hap/lib/Browser.js:155:6)
at /Users/ebaauw/GitHub/homebridge-lib/node_modules/bonjour-hap/lib/Browser.js:81:21
at Array.forEach (<anonymous>)
at EventEmitter._onresponse (/Users/ebaauw/GitHub/homebridge-lib/node_modules/bonjour-hap/lib/Browser.js:76:26)
```